### PR TITLE
feat: store hashed commit metadata

### DIFF
--- a/internal/commands/add/add.go
+++ b/internal/commands/add/add.go
@@ -224,6 +224,7 @@ func isEssentialFile(file string, essentials []string) bool {
 	return false
 }
 
+// TODO: move storeFileContent to utils package
 // storeFileContent saves the file content in the .got/objects directory
 func (a *Add) storeFileContet(filePath, hash string) error {
 	// take the firt two characters of the hash as the directory name

--- a/internal/commands/commit/commit_test.go
+++ b/internal/commands/commit/commit_test.go
@@ -60,6 +60,27 @@ func TestGetUserAndEmail(t *testing.T) {
 	if !strings.Contains(commitMetadata, "test commit") {
 		t.Errorf("Commit metadata does not contain the expected commit message")
 	}
+	// Create commit hash
+	commitHash := utils.HashContent(commitMetadata)
+	// check if folder with commit hash exists
+	commitFolder := filepath.Join(originalDir, ".got", "objects", commitHash[:2])
+	if _, err := os.Stat(commitFolder); os.IsNotExist(err) {
+		t.Errorf("Commit folder does not exist")
+	}
+	// Check if file with commit hash as name exists
+	commitFile := filepath.Join(commitFolder, commitHash[2:])
+	if _, err := os.Stat(commitFile); os.IsNotExist(err) {
+		t.Errorf("Commit file does not exist")
+	}
+	// // Check if the commit hash is stored in the .got/refs/heads/master file
+	// masterRefFile := filepath.Join(originalDir, ".got", "refs", "heads", "master")
+	// masterRefContent, err := os.ReadFile(masterRefFile)
+	// if err != nil {
+	// 	t.Fatalf("Error reading .got/refs/heads/master file: %v", err)
+	// }
+	// if string(masterRefContent) != commitHash {
+	// 	t.Errorf("Commit hash in .got/refs/heads/master does not match the expected commit hash")
+	// }
 }
 
 // TestReadStagedFiles


### PR DESCRIPTION
Create a folder inside .got/objects/, where the name is the first 2 characters of the hash and the rest becomes the name of the file

close #14 #15 #16